### PR TITLE
Admin edit user#115

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,6 +7,10 @@ class Admin::UsersController < Admin::BaseController
     @user = User.find(params[:id])
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
   def toggle_user
     user = User.find(params[:user_id])
     user.switch_enabled

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -31,16 +31,18 @@ class UsersController < ApplicationController
   end
 
   def update
-    @user = current_user
+    @user = current_user if current_default?
+    @user = User.find(params[:id]) if current_admin?
+
     updated = update_user(@user, params[:user])
     if updated
       @user.save
       flash[:success] = "You successfully edited your profile!"
-      redirect_to profile_path
+      flash[:success] = "You've successfully edited the user's profile!" if current_admin?
     else
       flash[:error] = "That email is already in use, please pick another"
-      redirect_to profile_edit_path
     end
+    redirect_after_update(updated)
   end
 
   private
@@ -49,7 +51,7 @@ class UsersController < ApplicationController
     params.require(:user).permit(:name, :password, :email, :address, :city, :state, :zip)
   end
 
-  def current_default
+  def current_default?
     current_session && current_user.role == 'default'
   end
 
@@ -64,6 +66,16 @@ class UsersController < ApplicationController
 
       return false if attribute == "email" && User.email_in_use?(value)
       user[attribute] = value
+    end
+  end
+
+  def redirect_after_update(successful_update)
+    if successful_update
+      redirect_to admin_user_path(@user) if current_admin?
+      redirect_to profile_path unless current_admin?
+    else
+      redirect_to edit_admin_user_path(@user) if current_admin?
+      redirect_to profile_edit_path unless current_admin?
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   end
 
   def show
-    render_404 unless current_default
+    render_404 unless current_default?
     @user = current_session
   end
 
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
   end
 
   def edit
-    render_404 unless current_default
+    render_404 unless current_default?
     @user = current_user
   end
 

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>User Edit Form</h1>
+<%= render partial: '/users/user_form' %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -13,7 +13,7 @@
 <p>City: <%= @user.city %></p>
 <p>State: <%= @user.state %></p>
 <p>Zip: <%= @user.zip %></p>
-<p>Edit Profile</p>
+<%= link_to "Edit Profile", edit_admin_user_path(@user) %>
 
 <% if @user.orders %>
 <section class='orders'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :merchants, only: [:index, :show]
-    resources :users, only: [:index, :show]
+    resources :users, only: [:index, :show, :edit, :update]
     resources :orders, only: [:destroy]
     post '/toggle', to: "merchants#toggle_status"
     post '/toggle-user', to: "users#toggle_user"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :merchants, only: [:index, :show]
-    resources :users, only: [:index, :show, :edit, :update]
+    resources :users, only: [:index, :show, :edit]
     resources :orders, only: [:destroy]
     post '/toggle', to: "merchants#toggle_status"
     post '/toggle-user', to: "users#toggle_user"

--- a/spec/features/users/admin/admin_can_edit_user_spec.rb
+++ b/spec/features/users/admin/admin_can_edit_user_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+describe "Admin Edit User" do
+  context "when admin visits edit_admin_user_path through admin_user_path" do
+    before :each do
+      @u = create(:user)
+      @a = create(:user, role: 2)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@a)
+    end
+
+    it 'does same behavior to edit as if default user except redirect' do
+      visit admin_user_path(@u)
+
+      click_link "Edit Profile"
+
+      expect(current_path).to eq(edit_admin_user_path(@u))
+
+      expect(find_field(:user_name).value).to eq @u.name
+      expect(find_field(:user_email).value).to eq @u.email
+      expect(find_field(:user_address).value).to eq @u.address
+      expect(find_field(:user_city).value).to eq @u.city
+      expect(find_field(:user_state).value).to eq @u.state
+      expect(find_field(:user_zip).value.to_i).to eq @u.zip
+
+      expect(find_field(:user_password).value).to be_nil
+
+      fill_in :user_name, with: "John"
+      fill_in :user_email, with: "john@gmail.com"
+
+      click_on "Update User"
+      expect(@u.name).to eq("John")
+      expect(@u.email).to eq("john@gmail.com")
+
+      expect(current_path).to eq(admin_user_path(@u))
+      expect(page).to have_content("You've successfully edited the user's profile!")
+    end
+  end
+end

--- a/spec/features/users/admin/admin_can_edit_user_spec.rb
+++ b/spec/features/users/admin/admin_can_edit_user_spec.rb
@@ -28,6 +28,9 @@ describe "Admin Edit User" do
       fill_in :user_email, with: "john@gmail.com"
 
       click_on "Update User"
+      @u.reload
+      expect(page).to have_content("John")
+      expect(page).to have_content("Email: john@gmail.com")
       expect(@u.name).to eq("John")
       expect(@u.email).to eq("john@gmail.com")
 


### PR DESCRIPTION
closes #115 

* Adds edit route to `Admin::UsersC` - `edit_admin_user`
  * Along with view (same as users#show)
  * link in `admin_user` to `edit_admin_user` 

* `users#edit` now works if current_user is either default or admin
  * adds helper method `redirect_after_update` to clean up code. Takes if successful update and redirects based on that and role of current_user
  * also different flash m for admin when successfully updated
