### PR TITLE
Merchant fulfill#70

### DIFF
--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -3,12 +3,22 @@ class OrderItemsController < ApplicationController
     merchant_or_admin?
 
     order_item = OrderItem.find(params[:order_item_id])
+    if order_item.item.enough_inventory?(order_item.quantity)
+      fulfill_and_update(order_item)
+      flash[:success] = "Order Item has been fulfilled!"
+    else
+      flash[:error] = "Not enough inventory to fulfill that item"
+    end
+    
+    redirect_to dashboard_order_path(order_item.order)
+  end
+
+  private
+
+  def fulfill_and_update(order_item)
     order_item.fulfilled = true
     order_item.save
     order_item.order.update_status
-    flash[:success] = "Order Item has been fulfilled!"
-
     order_item.item.decrease_inventory(order_item.quantity)
-    redirect_to dashboard_order_path(order_item.order)
   end
 end

--- a/app/models/Item.rb
+++ b/app/models/Item.rb
@@ -48,4 +48,8 @@ class Item < ApplicationRecord
   def decrease_inventory(amount)
     update(inventory: self.inventory - amount)
   end
+
+  def enough_inventory?(quantity_ordered)
+    inventory >= quantity_ordered
+  end
 end

--- a/app/views/dashboard/orders/show.html.erb
+++ b/app/views/dashboard/orders/show.html.erb
@@ -27,7 +27,11 @@
         <% if order_item.fulfilled %>
           <td>Fulfilled</td>
         <% else %>
-          <td><%= button_to "Fulfill", fulfill_order_item_path(order_item_id: order_item.order_item_id) %></td>
+          <% if order_item.order_item_quantity < order_item.item.inventory %>
+            <td><%= button_to "Fulfill", fulfill_order_item_path(order_item_id: order_item.order_item_id) %></td>
+          <% else %>
+            <td class="red-notice">Not Enough Inventory</td>
+          <% end %>
         <% end %>
       </tr>
     <% end %>

--- a/spec/features/users/merchant/merchant_can_fulfill_items_on_order_spec.rb
+++ b/spec/features/users/merchant/merchant_can_fulfill_items_on_order_spec.rb
@@ -40,5 +40,21 @@ describe "Merchant Order Item Fulfillment" do
     it 'shows text indicating an item has already been fulfilled' do
       expect(page).to have_content("Fulfilled")
     end
+
+    it "shows notice instead of fulfill button when quantity ordered exceeds item inventory" do
+      m = create(:user, role: 1)
+      i = create(:item, inventory: 3, user: m)
+
+      u = create(:user)
+      o = create(:order, user: u)
+      oi = create(:order_item, order: o, item: i, quantity: 5)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(m)
+      visit dashboard_order_path(o)
+
+      expect(i.inventory).to be < oi.quantity
+      expect(page).to_not have_button("Fulfill")
+      expect(page).to have_css("#red-notice")
+    end
   end
 end

--- a/spec/features/users/merchant/merchant_can_fulfill_items_on_order_spec.rb
+++ b/spec/features/users/merchant/merchant_can_fulfill_items_on_order_spec.rb
@@ -54,7 +54,8 @@ describe "Merchant Order Item Fulfillment" do
 
       expect(i.inventory).to be < oi.quantity
       expect(page).to_not have_button("Fulfill")
-      expect(page).to have_css("#red-notice")
+      expect(page).to have_css(".red-notice")
+      expect(page).to have_content("Not Enough Inventory")
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -194,6 +194,7 @@ describe Item, type: :model do
         i = create(:item, user: u, inventory: 4)
 
         expect(i.enough_inventory?(5)).to be_falsy
+        expect(i.enough_inventory?(4)).to be_truthy
         expect(i.enough_inventory?(3)).to be_truthy
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -188,6 +188,14 @@ describe Item, type: :model do
         i.decrease_inventory(2)
         expect(i.inventory).to eq(2)
       end
+
+      it "#enough_inventory?" do
+        u = create(:user, role: 1)
+        i = create(:item, user: u, inventory: 4)
+
+        expect(i.enough_inventory?(5)).to be_falsy
+        expect(i.enough_inventory?(3)).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
closes #70 

* Adds `Item#enough_inventory?`
* Updates `dashboard_order show to not show button and show `.red-notice` `<td>` instead if not enough inventory to fulfill order item
  * Adds sad path to `OrderItemsC#fulfill_order_item` - user won't have link to this path but can't fulfill anyway if they happened to POST here (if not enough inventory)