### PR TITLE
74 admin manage merchant items

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -35,6 +35,18 @@ class Admin::ItemsController < Admin::BaseController
     redirect_to admin_merchant_items_path(@item.user)
   end
 
+  def toggle_item
+    item = Item.find(params[:item_id])
+    item.toggle_enabled
+    item.reload
+
+    flash[:success] = item.enabled? ?
+      "Item is available for sale!" :
+      "Item is no longer available for sale!"
+
+    redirect_to admin_merchant_items_path(item.user)
+  end
+
   def destroy
     item = Item.find(params[:id])
     item.destroy

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,0 +1,35 @@
+class Admin::ItemsController < Admin::BaseController
+  def index
+    @merchant = User.find(params[:merchant_id])
+    @items = Item.where(user_id: @merchant.id)
+  end
+
+  def new
+    @item = Item.new
+  end
+
+  def create
+    @merchant = User.find(params[:merchant_id])
+    @item = @merchant.items.new(item_params)
+    if @item.save
+      flash[:success] = "Item added!"
+      redirect_to admin_merchant_items_path(@merchant)
+    else
+      flash[:error] = @item.errors.full_messages
+      render :new
+    end
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+    flash[:success] = "Item successfully deleted!"
+    redirect_to admin_merchant_items_path(item.user)
+  end
+
+  private
+
+    def item_params
+      params.require(:item).permit(:name, :description, :price, :thumbnail, :inventory)
+    end
+end

--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -5,6 +5,7 @@ class Admin::ItemsController < Admin::BaseController
   end
 
   def new
+    @merchant = User.find(params[:merchant_id])
     @item = Item.new
   end
 
@@ -20,6 +21,20 @@ class Admin::ItemsController < Admin::BaseController
     end
   end
 
+  def edit
+    @merchant = User.find(params[:merchant_id])
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+
+    update_item(@item, updated_item_params)
+
+    flash[:success] = "You successfully edited that item!"
+    redirect_to admin_merchant_items_path(@item.user)
+  end
+
   def destroy
     item = Item.find(params[:id])
     item.destroy
@@ -32,4 +47,17 @@ class Admin::ItemsController < Admin::BaseController
     def item_params
       params.require(:item).permit(:name, :description, :price, :thumbnail, :inventory)
     end
+
+    def updated_item_params
+      params.require(:item).permit(:name, :description, :price, :thumbnail, :inventory)
+    end
+
+    def update_item(item, params)
+      params.each do |attribute, value|
+        next if value.blank? || item[attribute] == value unless attribute == "thumbnail"
+        item[attribute] = value
+      end
+      item.save
+    end
+    
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,11 +1,14 @@
 class Admin::MerchantsController < Admin::BaseController
   def index
-      @merchants = User.where('role = 1')
+    @merchants = User.where('role = 1')
   end
 
   def show
     @user = User.find(params[:id])
     redirect_to admin_user_path(params[:id]) if @user.default?
+    @merchant = @user
+    @top_5 = @merchant.top_5 if @merchant.orders
+    @pending_orders = @merchant.pending_orders if @merchant.orders
   end
 
   def toggle_status

--- a/app/controllers/dashboard/items_controller.rb
+++ b/app/controllers/dashboard/items_controller.rb
@@ -38,7 +38,7 @@ class Dashboard::ItemsController < Dashboard::BaseController
   def update
     @item = Item.find(params[:id])
 
-    update_item(@item, params[:item])
+    update_item(@item, updated_item_params)
     flash[:success] = "You successfully edited that item!"
     redirect_to dashboard_items_path if current_merchant?
     redirect_to items_path if current_admin?
@@ -76,6 +76,10 @@ class Dashboard::ItemsController < Dashboard::BaseController
       params[:item][:thumbnail] = "no_img.jpg"
       params.require(:item).permit(:name, :description, :thumbnail, :price, :inventory)
     end
+  end
+
+  def updated_item_params
+    params.require(:item).permit(:name, :description, :price, :thumbnail, :inventory)
   end
 
   def update_item(item, params)

--- a/app/views/admin/items/_item_form.html.erb
+++ b/app/views/admin/items/_item_form.html.erb
@@ -1,0 +1,31 @@
+
+<div class="item_form-container">
+  <h1>Make an Item!</h1>
+  <%= form_for [:admin, :merchant, @item] do |f| %>
+    <div class="form-group">
+      <%= f.label :name %>
+      <%= f.text_field :name, class: "form-control", placeholder: "Enter name" %>
+    </div>
+    <div class="form-group">
+      <%= f.label :description %>
+      <%= f.text_field :description, class: "form-control", placeholder: "Enter description" %>
+    </div>
+    <div class="form-row">
+      <div class="form-group col-md-8">
+        <%= f.label :thumbnail %>
+        <%= f.text_field :thumbnail, class: "form-control", placeholder: "Enter thumbnail name" %>
+      </div>
+      <div class="form-group col-md-2">
+        <%= f.label :price %>
+        <%= f.number_field :price, class: "form-control", placeholder: "Enter $" %>
+      </div>
+      <div class="form-group col-md-2">
+        <%= f.label :inventory %>
+        <%= f.number_field :inventory, class: "form-control", placeholder: "Amount" %>
+      </div>
+     </div> 
+    <div class="form-group">
+      <%= f.submit class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Edit an Item!</h1>
+<%= render partial: '/admin/items/item_form' %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -28,9 +28,9 @@
                 <% else %>
                     <td><%= button_to "Enable", dashboard_toggle_item_path(item_id: item.id) %></td>
                 <% end %>
-                <td><%= link_to 'edit', edit_dashboard_item_path(item) %></td>
+                <td><%= link_to 'edit', edit_admin_merchant_item_path(@merchant, item) %></td>
                 <% unless item.ordered? %>
-                    <td><%= button_to 'delete', admin_item_path(item), method: :delete %></td>
+                    <td><%= button_to 'delete', admin_merchant_item_path(@merchant, item), method: :delete %></td>
                 <% end %>
             </tr>
         <% end %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,0 +1,41 @@
+<div class="vw-80">
+  <h1><%= @merchant.name %>'s Items</h1>
+  <table class="table table-bordered table-striped table-dark">
+    <thead>
+      <th scope="col">ID</th>
+      <th scope="col">Name</th>
+      <th scope="col">Thumbnail</th>
+      <th scope="col">Price</th>
+      <th scope="col">Inventory</th>
+      <th scope="col">Enable/Disable</th>
+      <th scope="col">Edit</th>
+    </thead>
+    <tbody>
+        <% @items.each do |item| %>
+            <tr id=<%="item-#{item.id}"%>>
+                <td><%= item.id%></td>
+                <td><%= item.name%></td>
+               <% item.thumbnail = "no_img" if item.thumbnail == ""%>
+                <% begin %>
+                  <td><%= image_tag("#{item.thumbnail}.jpg", id:("#{item.thumbnail}")) %></td>
+                <% rescue %>
+                  <td><%= image_tag("no_img.jpg", id:("no_img")) %></td>
+                <% end %>
+                <td><%= item.price%></td>
+                <td><%= item.inventory%></td>
+                <% if item.enabled? %>
+                    <td><%= button_to "Disable", dashboard_toggle_item_path(item_id: item.id) %></td>
+                <% else %>
+                    <td><%= button_to "Enable", dashboard_toggle_item_path(item_id: item.id) %></td>
+                <% end %>
+                <td><%= link_to 'edit', edit_dashboard_item_path(item) %></td>
+                <% unless item.ordered? %>
+                    <td><%= button_to 'delete', admin_item_path(item), method: :delete %></td>
+                <% end %>
+            </tr>
+        <% end %>
+    </tbody>
+  </table>
+<%= link_to 'add new item', new_admin_merchant_item_path %>
+</div>
+

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -24,9 +24,9 @@
                 <td><%= item.price%></td>
                 <td><%= item.inventory%></td>
                 <% if item.enabled? %>
-                    <td><%= button_to "Disable", dashboard_toggle_item_path(item_id: item.id) %></td>
+                    <td><%= button_to "Disable", admin_merchant_toggle_item_path(item_id: item.id) %></td>
                 <% else %>
-                    <td><%= button_to "Enable", dashboard_toggle_item_path(item_id: item.id) %></td>
+                    <td><%= button_to "Enable", admin_merchant_toggle_item_path(item_id: item.id) %></td>
                 <% end %>
                 <td><%= link_to 'edit', edit_admin_merchant_item_path(@merchant, item) %></td>
                 <% unless item.ordered? %>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: '/admin/items/item_form' %>

--- a/app/views/admin/merchants/show.html.erb
+++ b/app/views/admin/merchants/show.html.erb
@@ -1,3 +1,49 @@
-Merchant Page
+<section class="merchant-info">
+  <h1><%= @merchant.name %>'s Dashboard</h1>
+  <%= button_to "Downgrade to User", admin_toggle_role_path(id:params[:id]) %>
+  <div>
+    <table class="table table-bordered table-striped table-dark">
+      <thead>
+        <th scope="col">Email</th>
+        <th scope="col">Address</th>
+        <th scope="col">City</th>
+        <th scope="col">State</th>
+        <th scope="col">Zip</th>
+      </thead>
 
-<%= button_to "Downgrade to User", admin_toggle_role_path(id:params[:id]) %>
+      <tbody>
+          <td><%= @merchant.email %></td>
+          <td><%= @merchant.address %></td>
+          <td><%= @merchant.city %></td>
+          <td><%= @merchant.state %></td>
+          <td><%= @merchant.zip %></td>
+      </tbody>
+    </table>
+  </div>
+
+  <div id="top-5-items">
+    <h1>Top 5 Items</h1>
+    <ul>
+      <% @top_5.each do |item| %>
+      <li><%= item.name %></li>
+      <% end %>
+    </ul>
+  </div>
+
+<div id="pending-orders">
+  <h1>Pending Orders</h1>
+  <ul>
+    <% @pending_orders.each do |order| %>
+    <div id="pending-<%=order.id%>">
+      <li> <%= link_to "Order ID: #{order.id}", dashboard_order_path(order, merchant_id: @merchant.id) %> </li>
+      <li> Date Ordered: <%= order.created_at %></li>
+      <li> Quantity of My Items in Order: <%= order.quantity_of_my_items(@merchant) %></li>
+      <li> Total Value of My Items: $<%= order.value_of_my_items(@merchant) %></li>
+    </div>
+    <% end %>
+  </ul>
+
+</div>
+
+  <%= link_to "View My Items", dashboard_items_path %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,9 @@ Rails.application.routes.draw do
   resources :orders, only: [:create]
 
   namespace :admin do
-    resources :merchants, only: [:index, :show]
+    resources :merchants, shallow: true, only: [:index, :show] do
+      resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+    end
     resources :users, only: [:index, :show, :edit]
     resources :orders, only: [:destroy, :show]
     post '/toggle', to: "merchants#toggle_status"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resources :orders, only: [:create]
 
   namespace :admin do
-    resources :merchants, shallow: true, only: [:index, :show] do
+    resources :merchants, only: [:index, :show] do
       resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
     end
     resources :users, only: [:index, :show, :edit]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :merchants, only: [:index, :show] do
       resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
+      post '/toggle-item', to: 'items#toggle_item'
     end
     resources :users, only: [:index, :show, :edit]
     resources :orders, only: [:destroy, :show]

--- a/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
+++ b/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
@@ -2,71 +2,102 @@ require 'rails_helper'
 
 describe 'As an admin when I visit a merchants items' do
   describe 'I have access to all functionality the merchant does' do
-    it "can create and delete an item" do
-      admin = create(:user, role: 2)
-      merchant = create(:user, role: 1)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    context 'creat/delete functionality' do
+      it "can create and delete an item" do
+        admin = create(:user, role: 2)
+        merchant = create(:user, role: 1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 
-      visit admin_merchant_items_path(merchant)
+        visit admin_merchant_items_path(merchant)
 
-      click_on 'add new item'
+        click_on 'add new item'
 
-      expect(current_path).to eq(new_admin_merchant_item_path(merchant))
+        expect(current_path).to eq(new_admin_merchant_item_path(merchant))
 
-      fill_in "Name",	with: "Testing"
-      fill_in "Description",	with: "123"
-      fill_in "Price",	with: "11"
-      fill_in "Inventory",	with: "456"
-      click_on "Create Item"
+        fill_in "Name",	with: "Testing"
+        fill_in "Description",	with: "123"
+        fill_in "Price",	with: "11"
+        fill_in "Inventory",	with: "456"
+        click_on "Create Item"
 
-      expect(current_path).to eq(admin_merchant_items_path(merchant))
+        expect(current_path).to eq(admin_merchant_items_path(merchant))
 
-      expect(page).to have_content("Testing")
-      expect(page).to have_content("11")
-      expect(page).to have_content("456")
+        expect(page).to have_content("Testing")
+        expect(page).to have_content("11")
+        expect(page).to have_content("456")
 
-      expect(page).to have_content("Item added!")
+        expect(page).to have_content("Item added!")
 
-      item = Item.find_by(name: "Testing")
+        item = Item.find_by(name: "Testing")
 
-      within "#item-#{item.id}" do
-        expect(page).to have_button("delete")
-        click_button "delete"
+        within "#item-#{item.id}" do
+          expect(page).to have_button("delete")
+          click_button "delete"
+        end
+        
+        expect(page).to have_content("Item successfully deleted!")
+        
+        item = Item.find_by(name: "Testing")
+
+        expect(item).to_not be_truthy
       end
-      
-      expect(page).to have_content("Item successfully deleted!")
-      
-      item = Item.find_by(name: "Testing")
-
-      expect(item).to_not be_truthy
     end
 
-    it "sees a link to edit and can edit images" do
-      admin = create(:user, role: 2)
-      merchant = create(:user, role: 1)
-      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
-      item = create(:item, user: merchant, thumbnail: "plant_10")
-      visit admin_merchant_items_path(merchant)
+    context 'update functionality' do
+      it "sees a link to edit and can edit images" do
+        admin = create(:user, role: 2)
+        merchant = create(:user, role: 1)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+        item = create(:item, user: merchant, thumbnail: "plant_10")
+        visit admin_merchant_items_path(merchant)
 
-      within "#item-#{item.id}" do
-        click_link "edit"
+        within "#item-#{item.id}" do
+          click_link "edit"
+        end
+
+        expect(current_path).to eq(edit_admin_merchant_item_path(merchant, item))
+
+        fill_in "Name", with: "Cool name"
+        fill_in "Description", with: "Cool plant"
+        fill_in "Price", with: "11"
+        fill_in "Thumbnail", with: "plant_29"
+
+        click_button "Update Item"
+
+        item.reload
+
+        expect(current_path).to eq(admin_merchant_items_path(merchant))
+        expect(page).to have_content("Cool name")
+        expect(page).to have_content("11")
+        expect(page.find('#plant_29')['alt']).to match("Plant 29")
+      end
+    end
+
+    context 'enable/disable functionality' do
+      before :each do
+        @a = create(:user, role: 2)
+        @m = create(:user, role: 1)
+        @i_1 = create(:item, user: @m, enabled: true)
+        @i_2 = create(:item, user: @m)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@a)
+        visit admin_merchant_items_path(@m)
       end
 
-      expect(current_path).to eq(edit_admin_merchant_item_path(merchant, item))
+      it 'shows button to enable or disable and clicking redirects back to dashboard_items with flash message' do
+        expect(page).to have_button("Enable", count: 1)
+        expect(page).to have_button("Disable", count: 1)
 
-      fill_in "Name", with: "Cool name"
-      fill_in "Description", with: "Cool plant"
-      fill_in "Price", with: "11"
-      fill_in "Thumbnail", with: "plant_29"
-
-      click_button "Update Item"
-
-      item.reload
-
-      expect(current_path).to eq(admin_merchant_items_path(merchant))
-      expect(page).to have_content("Cool name")
-      expect(page).to have_content("11")
-      expect(page.find('#plant_29')['alt']).to match("Plant 29")
-    end
+        click_button "Enable"
+        expect(current_path).to eq(admin_merchant_items_path(@m))
+        expect(page).to have_content("Item is available for sale!")
+        expect(page).to have_button("Disable", count: 2)
+        
+        first(:button, "Disable").click
+        expect(page).to have_content("Item is no longer available for sale!")
+        expect(page).to have_button("Disable", count: 1)
+        expect(current_path).to eq(admin_merchant_items_path(@m))
+      end
+    end 
   end
 end

--- a/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
+++ b/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'As an admin when I visit a merchants items' do
+  describe 'I have access to all functionality the merchant does' do
+    it "can create and delete an item" do
+      admin = create(:user, role: 2)
+      merchant = create(:user, role: 1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_merchant_items_path(merchant)
+
+      click_on 'add new item'
+
+      expect(current_path).to eq(new_admin_merchant_item_path(merchant))
+
+      fill_in "Name",	with: "Testing"
+      fill_in "Description",	with: "123"
+      fill_in "Price",	with: "11"
+      fill_in "Inventory",	with: "456"
+      click_on "Create Item"
+
+      expect(current_path).to eq(admin_merchant_items_path(merchant))
+
+      expect(page).to have_content("Testing")
+      expect(page).to have_content("11")
+      expect(page).to have_content("456")
+
+      expect(page).to have_content("Item added!")
+
+      item = Item.find_by(name: "Testing")
+
+      within "#item-#{item.id}" do
+        expect(page).to have_button("delete")
+        click_button "delete"
+      end
+      
+      expect(page).to have_content("Item successfully deleted!")
+      
+      item = Item.find_by(name: "Testing")
+
+      expect(item).to_not be_truthy
+    end
+  end
+end

--- a/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
+++ b/spec/features/users/admin/admin_can_edit_items_for_merchant_spec.rb
@@ -40,5 +40,33 @@ describe 'As an admin when I visit a merchants items' do
 
       expect(item).to_not be_truthy
     end
+
+    it "sees a link to edit and can edit images" do
+      admin = create(:user, role: 2)
+      merchant = create(:user, role: 1)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+      item = create(:item, user: merchant, thumbnail: "plant_10")
+      visit admin_merchant_items_path(merchant)
+
+      within "#item-#{item.id}" do
+        click_link "edit"
+      end
+
+      expect(current_path).to eq(edit_admin_merchant_item_path(merchant, item))
+
+      fill_in "Name", with: "Cool name"
+      fill_in "Description", with: "Cool plant"
+      fill_in "Price", with: "11"
+      fill_in "Thumbnail", with: "plant_29"
+
+      click_button "Update Item"
+
+      item.reload
+
+      expect(current_path).to eq(admin_merchant_items_path(merchant))
+      expect(page).to have_content("Cool name")
+      expect(page).to have_content("11")
+      expect(page.find('#plant_29')['alt']).to match("Plant 29")
+    end
   end
 end

--- a/spec/features/users/admin/admin_sees_merchant_show_spec.rb
+++ b/spec/features/users/admin/admin_sees_merchant_show_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe "As an admin" do
+  describe "when I visit merchant dashboard" do
+    it "displays everything a merchant would see" do
+      admin = create(:user, email: "admin@admin.com", role:2)
+      merchant = create(:user, email: "test@test.com", role:1, )
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+      visit admin_merchant_path(merchant)
+
+      expect(page).to have_content("Email")
+      expect(page).to have_content("test@test.com")
+      expect(page).to have_content("Top 5 Items")
+      expect(page).to have_content("Pending Orders")
+      expect(page).to have_link("View My Items")
+    end
+  end
+end

--- a/spec/features/users/admin/admin_sees_merchants_index_spec.rb
+++ b/spec/features/users/admin/admin_sees_merchants_index_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe 'as an Admin' do
 
             expect(current_path).to eq("/admin/merchants/#{merchant.id}")
             expect(current_path).to eq(admin_merchant_path(merchant))
-            expect(page).to have_content("Merchant Page")
+            expect(page).to have_content("#{merchant.name}'s Dashboard")
         end
 
         it "default user can't visit admin_merchants_path" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe User, type: :model do
       end
 
       context "Merchant Statistics" do
-        xit 'displays the top 5 items by quantity' do
+        it 'displays the top 5 items by quantity' do
           #FIXME - being addressed currently - just pushing up the nav bar & filtration
 
           merchant = create(:user, role: 1)


### PR DESCRIPTION
resolves #74 

* Add missing merchant dashboard view for admin.
* Add strong params to dashboard item update method. (we could have been hacked!!! 😮)
* Adds all CRUD and toggle functionality to admin that merchant has for its items.
* Adds nested items resource to merchant resource under admin namespace.

NOTE: Could use refactor of utilizing rerender of dashboard views. I couldn't get it to work and pushed forward with creating separate views for admin/items. 
